### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "lora-training-in-comfy"
+description = "If you see this message, your ComfyUI-Manager is outdated.\nRecent channel provides only the list of the latest nodes. If you want to find the complete node list, please go to the Default channel.\nMaking LoRA has never been easier!"
+version = "1.0.0"
+license = "LICENSE"
+dependencies = ["accelerate==0.23.0", "transformers==4.30.2", "diffusers[torch]", "ftfy", "opencv-python", "einops", "pytorch-lightning", "tensorboard", "safetensors", "altair", "easygui", "toml", "voluptuous", "huggingface-hub", "open-clip-torch", "# extra", "rich", "pandas", "scipy", "requests", "pillow", "numpy", "gradio==3.41.2", "fastapi", "uvicorn", "lion-pytorch", "lycoris-lora", "prodigyopt", "dadaptation", "wandb", "httpx", "xformers", "# bitsandbytes", "bitsandbytes"]
+
+[project.urls]
+Repository = "https://github.com/LarryJane491/Lora-Training-in-Comfy"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "Lora-Training-in-Comfy"
+Icon = ""


### PR DESCRIPTION
We are working with dr.lt.data and comfyanon to build a global registry for custom nodes (similar to PyPI). Eventually, the registry will be used as a backend for the UI-manager. All nodes go through a verification process before being published to users.

The main benefits are that authors can
- publish nodes by version and users can safely update nodes knowing ahead of time if their workflows will break or not
- automate testing against new commits in the comfy repo and existing workflows through our CI/CD dashboard

Action Required:

- [ ] Go to the [registry](https://registry.comfy.org). Login and create a publisher id. Add the publisher id into the pyproject.toml file.
- [ ] Write a short description.
- [ ] Merge the separate Github Actions PR and run the workflow.

If you want to publish the node manually, [install the cli](https://docs.comfy.org/comfy-cli/getting-started#install-cli) and run `comfy node publish`

Check out our [docs](https://docs.comfy.org/registry/overview#introduction) if you want to know more about the registry. Otherwise, feel free to message me on discord at haohao_81202 or join our [server](https://discord.com/invite/comfyorg) if you have any questions!